### PR TITLE
Fix Py_None reference count

### DIFF
--- a/csrc/asyncmodule/asyncmodule.c
+++ b/csrc/asyncmodule/asyncmodule.c
@@ -228,6 +228,7 @@ Worker_try_get(Worker *self, PyObject *args, PyObject *kwds)
    /* Get an entry from the completion queue. */
    entry_t *e = async_try_get(self->worker);
    if (e == NULL) {
+      Py_INCREF(Py_None);
       return Py_None;
    }
 


### PR DESCRIPTION
I noticed that there's a case of `Py_None` being returned without having its refcount incremented.

Context: https://stackoverflow.com/questions/15287590/why-should-py-increfpy-none-be-required-before-returning-py-none-in-c/15288194#15288194